### PR TITLE
Feat/87 endpoint for edit namе bill

### DIFF
--- a/e2e_tests/test_bank_accounts.py
+++ b/e2e_tests/test_bank_accounts.py
@@ -67,6 +67,65 @@ class TestGetBankAccounts:
         assert resp.status_code == 401
 
 
+class TestRenameBankAccount:
+    def test_rename_success(self, http_client, auth_headers, bank_account):
+        _, headers = auth_headers
+        account_id = bank_account["bank_account_id"]
+
+        resp = http_client.patch(
+            f"/users/me/bank_account/{account_id}",
+            json={"bank_account_name": "Переименованный счёт"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["bank_account_name"] == "Переименованный счёт"
+        assert data["bank_account_id"] == account_id
+
+    def test_rename_reflects_in_list(self, http_client, auth_headers, bank_account):
+        _, headers = auth_headers
+        account_id = bank_account["bank_account_id"]
+
+        http_client.patch(
+            f"/users/me/bank_account/{account_id}",
+            json={"bank_account_name": "Новое имя"},
+            headers=headers,
+        )
+
+        list_resp = http_client.get("/users/me/bank_accounts", headers=headers)
+        assert list_resp.status_code == 200
+        accounts = list_resp.json()
+        account = next(a for a in accounts if a["bank_account_id"] == account_id)
+        assert account["bank_account_name"] == "Новое имя"
+
+    def test_rename_nonexistent_returns_404(self, http_client, auth_headers):
+        _, headers = auth_headers
+        resp = http_client.patch(
+            "/users/me/bank_account/999999",
+            json={"bank_account_name": "Новое имя"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    def test_rename_without_token_returns_401(self, http_client, bank_account):
+        account_id = bank_account["bank_account_id"]
+        resp = http_client.patch(
+            f"/users/me/bank_account/{account_id}",
+            json={"bank_account_name": "Новое имя"},
+        )
+        assert resp.status_code == 401
+
+    def test_rename_empty_name_returns_422(self, http_client, auth_headers, bank_account):
+        _, headers = auth_headers
+        account_id = bank_account["bank_account_id"]
+        resp = http_client.patch(
+            f"/users/me/bank_account/{account_id}",
+            json={"bank_account_name": "   "},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+
 class TestDeleteBankAccount:
     def test_delete_existing_account_returns_204(self, http_client, auth_headers, bank_account):
         _, headers = auth_headers

--- a/gateway/app/routers/bank_accounts.py
+++ b/gateway/app/routers/bank_accounts.py
@@ -265,6 +265,111 @@ async def get_bank_accounts(request: Request, current_user: dict = Depends(get_c
         raise HTTPException(status_code=e.response.status_code, detail=f"Ошибка: {e.response.text}")
 
 
+@router.patch(
+    "/bank_account/{bank_account_id}",
+    summary="✏️ Переименовать банковский счёт",
+    description="""
+🔐 **Требует авторизации** | JWT токен в заголовке Authorization
+
+Изменяет отображаемое название банковского счёта. Номер счёта, банк и баланс остаются неизменными.
+
+---
+
+## 📝 Параметры
+
+| Параметр | Тип | Расположение | Описание |
+|----------|-----|--------------|----------|
+| `bank_account_id` | integer | Path | ID счёта (из GET /bank_accounts) |
+| `bank_account_name` | string | Body | Новое название (1–100 символов) |
+
+---
+
+## 📤 Пример запроса
+
+```json
+{
+    "bank_account_name": "Моя основная карта"
+}
+```
+
+---
+
+## ✅ Пример успешного ответа
+
+```json
+{
+    "bank_account_id": 1,
+    "bank_account_name": "Моя основная карта",
+    "currency": "RUB",
+    "bank": "Сбербанк",
+    "balance": "125450.75"
+}
+```
+
+---
+
+## ❌ Возможные ошибки
+
+| Код | Описание |
+|-----|----------|
+| **401** | Невалидный или отсутствующий токен |
+| **404** | Счёт не найден или не принадлежит вам |
+| **422** | Пустое или слишком длинное название |
+| **504** | Сервис пользователей не отвечает |
+    """,
+    responses={
+        200: {
+            "description": "Счёт успешно переименован",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "bank_account_id": 1,
+                        "bank_account_name": "Моя основная карта",
+                        "currency": "RUB",
+                        "bank": "Сбербанк",
+                        "balance": "125450.75",
+                    }
+                }
+            },
+        },
+        401: {"description": "Не авторизован"},
+        404: {
+            "description": "Счёт не найден",
+            "content": {"application/json": {"example": {"detail": "Банковский счет не найден"}}},
+        },
+        422: {
+            "description": "Некорректное название",
+            "content": {"application/json": {"example": {"detail": "Name cannot be empty"}}},
+        },
+        504: {"description": "Таймаут при переименовании счёта"},
+    },
+)
+async def rename_bank_account(
+    bank_account_id: int,
+    request: Request,
+    body: dict,
+    current_user: dict = Depends(get_current_user),
+):
+    """Переименовать банковский счёт пользователя."""
+    client = get_http_client()
+    try:
+        cookies = dict(request.cookies)
+        response = await client.patch(
+            f"{USERS_SERVICE_URL}/users/me/bank_account/{bank_account_id}",
+            json=body,
+            headers={"Authorization": f"Bearer {current_user.get('token')}"},
+            cookies=cookies,
+        )
+        if response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Банковский счет не найден")
+        response.raise_for_status()
+        return response.json()
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Таймаут при переименовании счета")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=f"Ошибка: {e.response.text}")
+
+
 @router.delete(
     "/bank_account/{bank_account_id}",
     status_code=204,

--- a/gateway/app/routers/transactions.py
+++ b/gateway/app/routers/transactions.py
@@ -38,8 +38,9 @@ TRANSACTIONS_SERVICE_URL = os.getenv("TRANSACTIONS_SERVICE_URL", "http://transac
 | `min_amount` | float | Минимальная сумма |
 | `max_amount` | float | Максимальная сумма |
 | `merchant_ids` | list[int] | Список ID мерчантов |
+| `bank_account_ids` | list[int] | Список ID банковских счетов |
 | `limit` | int | Количество записей (1-100, обязательное) |
-| `offset` | int | Смещение для пагинации | 
+| `offset` | int | Смещение для пагинации |
 
 ## Примеры запросов
 
@@ -69,6 +70,14 @@ TRANSACTIONS_SERVICE_URL = os.getenv("TRANSACTIONS_SERVICE_URL", "http://transac
     "min_amount": 5000,
     "limit": 20,
     "offset": 0
+}
+```
+
+### По конкретным счетам
+```json
+{
+    "bank_account_ids": [1, 3],
+    "limit": 50
 }
 ```
 """,

--- a/gateway/app/schemas/transaction_schema.py
+++ b/gateway/app/schemas/transaction_schema.py
@@ -16,6 +16,7 @@ class TransactionFilterRequest(BaseModel):
     min_amount: Optional[float] = Field(None, ge=0, description="Минимальная сумма транзакции")
     max_amount: Optional[float] = Field(None, ge=0, description="Максимальная сумма транзакции")
     merchant_ids: Optional[List[int]] = Field(None, description="Список ID мерчантов для фильтрации")
+    bank_account_ids: Optional[List[int]] = Field(None, description="Список ID банковских счетов для фильтрации")
     limit: int = Field(..., ge=1, le=100, description="Количество записей на странице")
     offset: int = Field(0, ge=0, description="Смещение для пагинации")
 

--- a/gateway/tests/integration/test_bank_accounts.py
+++ b/gateway/tests/integration/test_bank_accounts.py
@@ -150,6 +150,70 @@ class TestGetBankAccounts:
 
 
 # ──────────────────────────────────────────────────────────────
+# PATCH /users/me/bank_account/{id}  — переименовать счёт
+# ──────────────────────────────────────────────────────────────
+class TestRenameBankAccount:
+    async def test_success(self, client):
+        renamed = {**BANK_ACCOUNT_RESPONSE, "bank_account_name": "Новое имя"}
+        mock_http = AsyncMock()
+        mock_resp = make_mock_http_response(200, json_data=renamed)
+        mock_resp.raise_for_status = MagicMock()
+        mock_http.patch.return_value = mock_resp
+        with patch("app.routers.bank_accounts.get_http_client", return_value=mock_http):
+            response = await client.patch(
+                "/users/me/bank_account/1", json={"bank_account_name": "Новое имя"}
+            )
+
+        assert response.status_code == 200
+        assert response.json()["bank_account_name"] == "Новое имя"
+
+    async def test_not_found_returns_404(self, client):
+        mock_http = AsyncMock()
+        mock_http.patch.return_value = make_mock_http_response(404, json_data={"detail": "Not found"})
+        with patch("app.routers.bank_accounts.get_http_client", return_value=mock_http):
+            response = await client.patch(
+                "/users/me/bank_account/999", json={"bank_account_name": "Что-то"}
+            )
+
+        assert response.status_code == 404
+        assert "не найден" in response.json()["detail"]
+
+    async def test_timeout_returns_504(self, client):
+        mock_http = AsyncMock()
+        mock_http.patch.side_effect = httpx.TimeoutException("Timeout")
+        with patch("app.routers.bank_accounts.get_http_client", return_value=mock_http):
+            response = await client.patch(
+                "/users/me/bank_account/1", json={"bank_account_name": "Новое имя"}
+            )
+
+        assert response.status_code == 504
+
+    async def test_no_token_returns_401(self, client_no_auth):
+        response = await client_no_auth.patch(
+            "/users/me/bank_account/1", json={"bank_account_name": "Новое имя"}
+        )
+        assert response.status_code == 401
+
+    async def test_upstream_5xx_raises(self, client):
+        mock_http = AsyncMock()
+        mock_resp = make_mock_http_response(500, json_data={"detail": "Internal"})
+        mock_resp.text = "Internal Server Error"
+        err_resp = MagicMock()
+        err_resp.status_code = 500
+        err_resp.text = "Internal Server Error"
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("error", request=MagicMock(), response=err_resp)
+        )
+        mock_http.patch.return_value = mock_resp
+        with patch("app.routers.bank_accounts.get_http_client", return_value=mock_http):
+            response = await client.patch(
+                "/users/me/bank_account/1", json={"bank_account_name": "Новое имя"}
+            )
+
+        assert response.status_code == 500
+
+
+# ──────────────────────────────────────────────────────────────
 # DELETE /users/me/bank_account/{id}  — удалить банковский счёт
 # ──────────────────────────────────────────────────────────────
 class TestDeleteBankAccount:

--- a/gateway/tests/integration/test_transactions.py
+++ b/gateway/tests/integration/test_transactions.py
@@ -103,6 +103,29 @@ class TestGetTransactions:
         response = await client_no_auth.post("/transactions/", json={"limit": 10})
         assert response.status_code == 401
 
+    async def test_bank_account_ids_filter_passed_to_downstream(self, client):
+        """bank_account_ids передаётся в downstream как часть JSON-тела"""
+        mock_http = AsyncMock()
+        mock_http.post.return_value = make_mock_http_response(200, json_data=[])
+        with patch("app.routers.transactions.get_http_client", return_value=mock_http):
+            response = await client.post("/transactions/", json={"limit": 10, "bank_account_ids": [1, 2]})
+
+        assert response.status_code == 200
+        body_sent = mock_http.post.call_args.kwargs["json"]
+        assert body_sent["bank_account_ids"] == [1, 2]
+
+    async def test_bank_account_ids_filter_returns_filtered_list(self, client):
+        """Результат с bank_account_ids корректно возвращается клиенту"""
+        mock_http = AsyncMock()
+        mock_http.post.return_value = make_mock_http_response(200, json_data=TRANSACTION_LIST)
+        with patch("app.routers.transactions.get_http_client", return_value=mock_http):
+            response = await client.post("/transactions/", json={"limit": 10, "bank_account_ids": [1]})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert data[0]["bank_account_id"] == 1
+
 
 # ──────────────────────────────────────────────────────────────
 # GET /transactions/categories  — получить категории

--- a/purposes_service/app/repository/purpose_repository.py
+++ b/purposes_service/app/repository/purpose_repository.py
@@ -57,14 +57,15 @@ class PurposeRepository:
         # При создании amount=0, поэтому пороги не пересекаются
         # (оставлено для совместимости, если amount будет задаваться при создании)
         crossed = get_crossed_thresholds(0, purpose.total_amount, purpose.amount, purpose.total_amount)
-        for threshold in crossed:
+        if crossed:
+            max_threshold = max(crossed)
             progress_percent = (purpose.amount / purpose.total_amount) * 100
             event_data_progress = {
                 "user_id": user_id,
                 "purpose_id": str(purpose.id),
                 "purpose_name": purpose.title,
                 "progress_percent": round(progress_percent, 2),
-                "threshold": threshold,
+                "threshold": max_threshold,
             }
             publisher = EventPublisher()
             event_progress = DomainEvent(
@@ -139,14 +140,15 @@ class PurposeRepository:
         if "amount" in update_data or "total_amount" in update_data:
             crossed = get_crossed_thresholds(old_amount, old_total_amount, new_amount, new_total_amount)
 
-            for threshold in crossed:
+            if crossed:
+                max_threshold = max(crossed)
                 progress_percent = (new_amount / new_total_amount) * 100
                 event_data = {
                     "user_id": user_id,
                     "purpose_id": str(purpose.id),
                     "purpose_name": purpose.title,
                     "progress_percent": round(progress_percent, 2),
-                    "threshold": threshold,
+                    "threshold": max_threshold,
                 }
                 publisher = EventPublisher()
                 event = DomainEvent(

--- a/transactions_service/app/event_listener.py
+++ b/transactions_service/app/event_listener.py
@@ -89,6 +89,7 @@ class EventListener:
 
     _event_handlers = {
         "bank_account.added": "_handle_bank_account_added",
+        "bank_account.renamed": "_handle_bank_account_renamed",
     }
 
     async def handle_event(self, event: DomainEvent):
@@ -99,6 +100,29 @@ class EventListener:
                 await handler(event)
         except Exception as e:
             logger.error(f"[EventListener] Ошибка обработки события {event.event_type}: {e}")
+
+    async def _handle_bank_account_renamed(self, event: DomainEvent):
+        """Обновить имя счёта при переименовании"""
+        payload = event.payload
+        bank_account_hash = payload.get("bank_account_hash")
+        new_name = payload.get("new_name")
+
+        if not bank_account_hash or not new_name:
+            logger.error(f"[EventListener] Отсутствует bank_account_hash или new_name: {payload}")
+            return
+
+        logger.info(f"[EventListener] Переименование счёта {bank_account_hash} → «{new_name}»")
+
+        async with AsyncSessionLocal() as db:
+            repo = SyncRepository(db)
+            try:
+                found = await repo.rename_bank_account(bank_account_hash, new_name)
+                if found:
+                    logger.info(f"[EventListener] Счёт {bank_account_hash} переименован")
+                else:
+                    logger.warning(f"[EventListener] Счёт {bank_account_hash} не найден в transactions DB")
+            except Exception as e:
+                logger.error(f"[EventListener] Ошибка переименования {bank_account_hash}: {e}")
 
     async def _handle_bank_account_added(self, event: DomainEvent):
         """Синхронизировать счёт при добавлении банковского аккаунта"""

--- a/transactions_service/app/repository/sync_repository.py
+++ b/transactions_service/app/repository/sync_repository.py
@@ -126,12 +126,32 @@ class SyncRepository:
             return {"categories": 0, "mcc": 0, "merchants": 0, "banks": 0, "bank_accounts": 0, "transactions": 0}
 
         try:
-            return await self._do_sync(bank_account_hash, user_id)
+            stats = await self._do_sync(bank_account_hash, user_id)
         finally:
             try:
                 await cache_client.redis.delete(lock_key)
             except Exception:
                 pass
+
+        try:
+            publisher = EventPublisher()
+            event = DomainEvent(
+                event_id=str(uuid4()),
+                event_type="sync.completed",
+                source="transactions-service",
+                timestamp=datetime.now(),
+                payload={
+                    "user_id": user_id,
+                    "bank_account_hash": bank_account_hash,
+                    "new_transactions_count": stats["transactions"],
+                    "synced_at": datetime.now().isoformat(),
+                },
+            )
+            await publisher.publish(event)
+        except Exception as e:
+            logger.warning(f"[SYNC] Не удалось опубликовать sync.completed: {e}")
+
+        return stats
 
     async def _do_sync(self, bank_account_hash: str, user_id: int) -> Dict[str, int]:
         logger.info(f"[SYNC] Starting sync for account {bank_account_hash}, user_id={user_id}")
@@ -207,24 +227,6 @@ class SyncRepository:
 
         await self.db.commit()
 
-        try:
-            publisher = EventPublisher()
-            event = DomainEvent(
-                event_id=str(uuid4()),
-                event_type="sync.completed",
-                source="transactions-service",
-                timestamp=datetime.now(),
-                payload={
-                    "user_id": user_id,
-                    "bank_account_hash": bank_account_hash,
-                    "new_transactions_count": stats["transactions"],
-                    "synced_at": datetime.now().isoformat(),
-                },
-            )
-            await publisher.publish(event)
-        except Exception as e:
-            logger.warning(f"[SYNC] Не удалось опубликовать sync.completed: {e}")
-
         return stats
 
     async def rename_bank_account(self, bank_account_hash: str, new_name: str) -> bool:
@@ -258,15 +260,34 @@ class SyncRepository:
         # Новые счета появятся после первого вызова trigger_sync.
         account_hashes = await self.get_user_account_hashes(user_id)
 
-        total = {"processed": len(account_hashes), "success": 0, "failed": 0}
+        total = {"processed": len(account_hashes), "success": 0, "failed": 0, "transactions": 0}
 
         for acc_hash in account_hashes:
             try:
-                await self.sync_by_account(acc_hash, user_id)
+                stats = await self._do_sync(acc_hash, user_id)
                 total["success"] += 1
+                total["transactions"] += stats["transactions"]
             except Exception as e:
                 print(f"Failed to sync {acc_hash} for user {user_id}: {e}")
                 total["failed"] += 1
+
+        if total["success"] > 0:
+            try:
+                publisher = EventPublisher()
+                event = DomainEvent(
+                    event_id=str(uuid4()),
+                    event_type="sync.completed",
+                    source="transactions-service",
+                    timestamp=datetime.now(),
+                    payload={
+                        "user_id": user_id,
+                        "new_transactions_count": total["transactions"],
+                        "synced_at": datetime.now().isoformat(),
+                    },
+                )
+                await publisher.publish(event)
+            except Exception as e:
+                logger.warning(f"[SYNC] Не удалось опубликовать sync.completed: {e}")
 
         return total
 

--- a/transactions_service/app/repository/sync_repository.py
+++ b/transactions_service/app/repository/sync_repository.py
@@ -227,6 +227,18 @@ class SyncRepository:
 
         return stats
 
+    async def rename_bank_account(self, bank_account_hash: str, new_name: str) -> bool:
+        """Переименовать банковский счёт по хэшу. Возвращает True если счёт найден."""
+        result = await self.db.execute(
+            select(Bank_Account).where(Bank_Account.bank_account_hash == bank_account_hash)
+        )
+        account = result.scalars().first()
+        if not account:
+            return False
+        account.bank_account_name = new_name
+        await self.db.commit()
+        return True
+
     async def get_all_active_account_hashes(self) -> list[tuple[str, int]]:
         """Возвращает [(bank_account_hash, user_id)]"""
         result = await self.db.execute(

--- a/transactions_service/app/repository/transactions_repository.py
+++ b/transactions_service/app/repository/transactions_repository.py
@@ -21,6 +21,7 @@ class TransactionRepository:
         min_amount: Optional[float] = None,
         max_amount: Optional[float] = None,
         merchant_ids: Optional[List[int]] = None,
+        bank_account_ids: Optional[List[int]] = None,
         limit: int = 50,
         offset: int = 0,
     ):
@@ -68,6 +69,9 @@ class TransactionRepository:
 
         if merchant_ids:
             query = query.where(Transaction.merchant_id.in_(merchant_ids))
+
+        if bank_account_ids:
+            query = query.where(Transaction.bank_account_id.in_(bank_account_ids))
 
         query = query.order_by(Transaction.created_at.desc()).limit(limit).offset(offset)
 

--- a/transactions_service/app/routers/transactions.py
+++ b/transactions_service/app/routers/transactions.py
@@ -63,6 +63,7 @@ async def get_transactions(
             min_amount=filters.min_amount,
             max_amount=filters.max_amount,
             merchant_ids=filters.merchant_ids,
+            bank_account_ids=filters.bank_account_ids,
             limit=filters.limit,
             offset=filters.offset,
         )

--- a/transactions_service/app/schemas.py
+++ b/transactions_service/app/schemas.py
@@ -19,6 +19,7 @@ class TransactionFilterRequest(BaseModel):
     min_amount: Optional[float] = Field(None, ge=0, description="Минимальная сумма")
     max_amount: Optional[float] = Field(None, ge=0, description="Максимальная сумма")
     merchant_ids: Optional[List[int]] = Field(None, description="Список ID мерчантов")
+    bank_account_ids: Optional[List[int]] = Field(None, description="Список ID банковских счетов")
     limit: int = Field(..., ge=1, le=1000)
     offset: int = Field(0, ge=0)
 

--- a/transactions_service/tests/integration/test_sync_integration.py
+++ b/transactions_service/tests/integration/test_sync_integration.py
@@ -135,8 +135,14 @@ class TestSyncIntegration:
         mock_client_instance = AsyncMock()
         mock_client_instance.get.return_value = mock_response
 
-        with patch("app.repository.sync_repository.httpx.AsyncClient") as mock_http:
+        with (
+            patch("app.repository.sync_repository.httpx.AsyncClient") as mock_http,
+            patch("app.repository.sync_repository.EventPublisher") as mock_publisher_cls,
+        ):
             mock_http.return_value.__aenter__.return_value = mock_client_instance
+            mock_publisher = AsyncMock()
+            mock_publisher.publish = AsyncMock()
+            mock_publisher_cls.return_value = mock_publisher
 
             response = await client.post("/transactions/sync_user_accounts", json={"user_id": 123})
 
@@ -144,10 +150,16 @@ class TestSyncIntegration:
         assert response.status_code == 200
         assert response.json()["success"] == 1
 
-        # Проверяем, что счет обновился
+        # Проверяем что счет обновился
         await db_session.refresh(existing_acc)
         assert existing_acc.bank_account_name == "New Name"
         assert float(existing_acc.balance) == 500.00
+
+        # Проверяем ровно одно событие sync.completed на весь batch
+        mock_publisher.publish.assert_awaited_once()
+        event = mock_publisher.publish.await_args.args[0]
+        assert event.event_type == "sync.completed"
+        assert event.payload["user_id"] == 123
 
     @pytest.mark.asyncio
     async def test_sync_incremental_logic(self, client: AsyncClient, db_session):

--- a/transactions_service/tests/integration/test_transactions_integration.py
+++ b/transactions_service/tests/integration/test_transactions_integration.py
@@ -504,3 +504,67 @@ async def test_category_summary_excludes_other_users(client: AsyncClient, db_ses
     data = response.json()
     assert len(data) == 1
     assert data[0]["total_amount"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_filter_by_bank_account_ids(client: AsyncClient, db_session: AsyncSession):
+    """Тест: фильтрация транзакций по bank_account_ids"""
+    user_id = 123
+
+    bank = Bank(id=10, name="Filter Bank")
+    category = Category(id=30, name="Filter Cat")
+    account_a = Bank_Account(id=10, user_id=user_id, bank_account_hash="hash_a", bank_account_name="A", bank_id=10, currency="RUB", balance=0)
+    account_b = Bank_Account(id=11, user_id=user_id, bank_account_hash="hash_b", bank_account_name="B", bank_id=10, currency="RUB", balance=0)
+    db_session.add_all([bank, category, account_a, account_b])
+    await db_session.flush()
+
+    tx_a = Transaction(id=uuid.uuid4(), user_id=user_id, category_id=30, bank_account_id=10, amount=100.0, type="expense", created_at=datetime(2026, 1, 1))
+    tx_b = Transaction(id=uuid.uuid4(), user_id=user_id, category_id=30, bank_account_id=11, amount=200.0, type="expense", created_at=datetime(2026, 1, 2))
+    db_session.add_all([tx_a, tx_b])
+    await db_session.flush()
+
+    response = await client.post("/transactions/", json={"limit": 10, "bank_account_ids": [10]})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["bank_account_id"] == 10
+    assert data[0]["amount"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_filter_by_bank_account_ids_multiple(client: AsyncClient, db_session: AsyncSession):
+    """Тест: фильтр по нескольким счетам возвращает транзакции по каждому"""
+    user_id = 123
+
+    bank = Bank(id=20, name="Multi Bank")
+    category = Category(id=40, name="Multi Cat")
+    account_1 = Bank_Account(id=20, user_id=user_id, bank_account_hash="hash_m1", bank_account_name="M1", bank_id=20, currency="RUB", balance=0)
+    account_2 = Bank_Account(id=21, user_id=user_id, bank_account_hash="hash_m2", bank_account_name="M2", bank_id=20, currency="RUB", balance=0)
+    account_3 = Bank_Account(id=22, user_id=user_id, bank_account_hash="hash_m3", bank_account_name="M3", bank_id=20, currency="RUB", balance=0)
+    db_session.add_all([bank, category, account_1, account_2, account_3])
+    await db_session.flush()
+
+    db_session.add_all([
+        Transaction(id=uuid.uuid4(), user_id=user_id, category_id=40, bank_account_id=20, amount=10.0, type="expense", created_at=datetime(2026, 1, 1)),
+        Transaction(id=uuid.uuid4(), user_id=user_id, category_id=40, bank_account_id=21, amount=20.0, type="expense", created_at=datetime(2026, 1, 2)),
+        Transaction(id=uuid.uuid4(), user_id=user_id, category_id=40, bank_account_id=22, amount=30.0, type="expense", created_at=datetime(2026, 1, 3)),
+    ])
+    await db_session.flush()
+
+    response = await client.post("/transactions/", json={"limit": 10, "bank_account_ids": [20, 21]})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    account_ids_returned = {t["bank_account_id"] for t in data}
+    assert account_ids_returned == {20, 21}
+
+
+@pytest.mark.asyncio
+async def test_filter_by_nonexistent_bank_account_returns_empty(client: AsyncClient, db_session: AsyncSession):
+    """Тест: фильтр по несуществующему счёту возвращает пустой список"""
+    response = await client.post("/transactions/", json={"limit": 10, "bank_account_ids": [99999]})
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/transactions_service/tests/unit/routers/test_sync.py
+++ b/transactions_service/tests/unit/routers/test_sync.py
@@ -273,19 +273,67 @@ class TestSyncRepository:
 
     @pytest.mark.asyncio
     async def test_sync_user_accounts(self, sync_repository):
-        """Тест синхронизации счетов конкретного пользователя"""
+        """sync_user_accounts вызывает _do_sync для каждого счёта"""
         user_id = 555
         hashes = ["acc1", "acc2"]
 
         with (
             patch.object(sync_repository, "get_user_account_hashes", new_callable=AsyncMock) as mock_get_hashes,
-            patch.object(sync_repository, "sync_by_account", new_callable=AsyncMock) as mock_sync,
+            patch.object(sync_repository, "_do_sync", new_callable=AsyncMock) as mock_do_sync,
+            patch("app.repository.sync_repository.EventPublisher") as mock_publisher_cls,
         ):
             mock_get_hashes.return_value = hashes
-            mock_sync.return_value = {"transactions": 0}
+            mock_do_sync.return_value = {"transactions": 3, "categories": 0, "mcc": 0, "merchants": 0, "banks": 0, "bank_accounts": 0}
+            mock_publisher_cls.return_value.publish = AsyncMock()
 
             result = await sync_repository.sync_user_accounts(user_id)
 
         assert result["success"] == 2
+        assert result["transactions"] == 6
         mock_get_hashes.assert_awaited_once_with(user_id)
-        mock_sync.assert_any_await("acc1", user_id)
+        mock_do_sync.assert_any_await("acc1", user_id)
+        mock_do_sync.assert_any_await("acc2", user_id)
+
+    async def test_sync_user_accounts_publishes_single_event(self, sync_repository):
+        """sync_user_accounts публикует ровно одно sync.completed со суммарной статистикой"""
+        user_id = 42
+        hashes = ["h1", "h2", "h3"]
+
+        with (
+            patch.object(sync_repository, "get_user_account_hashes", new_callable=AsyncMock) as mock_get_hashes,
+            patch.object(sync_repository, "_do_sync", new_callable=AsyncMock) as mock_do_sync,
+            patch("app.repository.sync_repository.EventPublisher") as mock_publisher_cls,
+        ):
+            mock_get_hashes.return_value = hashes
+            mock_do_sync.return_value = {"transactions": 5, "categories": 0, "mcc": 0, "merchants": 0, "banks": 0, "bank_accounts": 0}
+            mock_publisher = AsyncMock()
+            mock_publisher.publish = AsyncMock()
+            mock_publisher_cls.return_value = mock_publisher
+
+            await sync_repository.sync_user_accounts(user_id)
+
+        mock_publisher.publish.assert_awaited_once()
+        event = mock_publisher.publish.await_args.args[0]
+        assert event.event_type == "sync.completed"
+        assert event.payload["user_id"] == user_id
+        assert event.payload["new_transactions_count"] == 15  # 3 счёта × 5
+
+    async def test_sync_user_accounts_no_event_when_all_failed(self, sync_repository):
+        """sync.completed не публикуется если все счета упали с ошибкой"""
+        user_id = 7
+        hashes = ["bad1", "bad2"]
+
+        with (
+            patch.object(sync_repository, "get_user_account_hashes", new_callable=AsyncMock) as mock_get_hashes,
+            patch.object(sync_repository, "_do_sync", new_callable=AsyncMock) as mock_do_sync,
+            patch("app.repository.sync_repository.EventPublisher") as mock_publisher_cls,
+        ):
+            mock_get_hashes.return_value = hashes
+            mock_do_sync.side_effect = Exception("pseudo_bank down")
+            mock_publisher = AsyncMock()
+            mock_publisher_cls.return_value = mock_publisher
+
+            result = await sync_repository.sync_user_accounts(user_id)
+
+        assert result["success"] == 0
+        mock_publisher.publish.assert_not_awaited()

--- a/transactions_service/tests/unit/routers/test_transactions.py
+++ b/transactions_service/tests/unit/routers/test_transactions.py
@@ -107,6 +107,35 @@ class TestGetTransactions:
         assert called_kwargs["category_ids"] == [1, 2]
 
     @pytest.mark.asyncio
+    async def test_get_transactions_filter_by_bank_account(self, client, mock_db_session):
+        """Тест: фильтр по bank_account_ids передаётся в репозиторий"""
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get_transactions_with_filters = AsyncMock(return_value=[])
+
+        with patch("app.routers.transactions.TransactionRepository", return_value=mock_repo_instance):
+            response = client.post(
+                "/transactions/",
+                json={"limit": 10, "bank_account_ids": [1, 2]},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        called_kwargs = mock_repo_instance.get_transactions_with_filters.call_args.kwargs
+        assert called_kwargs["bank_account_ids"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_get_transactions_without_bank_account_filter(self, client, mock_db_session):
+        """Тест: без bank_account_ids фильтр передаётся как None"""
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get_transactions_with_filters = AsyncMock(return_value=[])
+
+        with patch("app.routers.transactions.TransactionRepository", return_value=mock_repo_instance):
+            response = client.post("/transactions/", json={"limit": 10})
+
+        assert response.status_code == status.HTTP_200_OK
+        called_kwargs = mock_repo_instance.get_transactions_with_filters.call_args.kwargs
+        assert called_kwargs["bank_account_ids"] is None
+
+    @pytest.mark.asyncio
     async def test_get_transactions_internal_error(self, client, mock_db_session):
         """Тест: внутренняя ошибка сервера (Exception -> HTTP 500)"""
         mock_repo_instance = MagicMock()

--- a/transactions_service/tests/unit/test_event_listener.py
+++ b/transactions_service/tests/unit/test_event_listener.py
@@ -103,6 +103,74 @@ class TestEventListener:
         await listener.handle_event(event)
 
     @pytest.mark.asyncio
+    async def test_handle_bank_account_renamed_calls_rename(self):
+        """При получении bank_account.renamed вызывается rename_bank_account"""
+        from app.event_listener import EventListener
+
+        event = _make_event(
+            "bank_account.renamed",
+            {"user_id": 1, "bank_account_hash": "abc123", "new_name": "Новое имя"},
+        )
+
+        mock_repo = AsyncMock()
+        mock_repo.rename_bank_account = AsyncMock(return_value=True)
+
+        with (
+            patch("app.event_listener.AsyncSessionLocal") as mock_session_local,
+            patch("app.event_listener.SyncRepository", return_value=mock_repo),
+        ):
+            mock_session_local.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            mock_session_local.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            listener = EventListener()
+            await listener._handle_bank_account_renamed(event)
+
+        mock_repo.rename_bank_account.assert_awaited_once_with("abc123", "Новое имя")
+
+    @pytest.mark.asyncio
+    async def test_handle_bank_account_renamed_missing_fields(self):
+        """Если отсутствует hash или new_name — rename не вызывается"""
+        from app.event_listener import EventListener
+
+        event = _make_event("bank_account.renamed", {"user_id": 1})
+
+        mock_repo = AsyncMock()
+
+        with (
+            patch("app.event_listener.AsyncSessionLocal"),
+            patch("app.event_listener.SyncRepository", return_value=mock_repo),
+        ):
+            listener = EventListener()
+            await listener._handle_bank_account_renamed(event)
+
+        mock_repo.rename_bank_account.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_bank_account_renamed_account_not_found(self):
+        """Если счёт не найден в transactions DB — ошибки нет"""
+        from app.event_listener import EventListener
+
+        event = _make_event(
+            "bank_account.renamed",
+            {"user_id": 1, "bank_account_hash": "unknown_hash", "new_name": "Имя"},
+        )
+
+        mock_repo = AsyncMock()
+        mock_repo.rename_bank_account = AsyncMock(return_value=False)
+
+        with (
+            patch("app.event_listener.AsyncSessionLocal") as mock_session_local,
+            patch("app.event_listener.SyncRepository", return_value=mock_repo),
+        ):
+            mock_session_local.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            mock_session_local.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            listener = EventListener()
+            await listener._handle_bank_account_renamed(event)
+
+        mock_repo.rename_bank_account.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_handle_bank_account_added_sync_error_is_caught(self):
         """Ошибка sync_by_account не пробрасывается наружу"""
         from app.event_listener import EventListener

--- a/users_service/app/repository/bank_account_repository.py
+++ b/users_service/app/repository/bank_account_repository.py
@@ -131,6 +131,39 @@ class Bank_AccountRepository:
         # Возвращаем account и hash для фоновой синхронизации
         return new_account, account_hash
 
+    async def rename(self, bank_account_id: int, user_id: int, new_name: str):
+        """Переименовать банковский счёт"""
+        from sqlalchemy.orm import selectinload
+
+        result = await self.db.execute(
+            select(Bank_Accounts)
+            .options(selectinload(Bank_Accounts.bank))
+            .where(Bank_Accounts.bank_account_id == bank_account_id, Bank_Accounts.user_id == user_id)
+        )
+        account = result.scalars().first()
+        if not account:
+            return None
+
+        account.bank_account_name = new_name
+        await self.db.commit()
+        await self.db.refresh(account)
+
+        publisher = EventPublisher()
+        event = DomainEvent(
+            event_id=str(uuid4()),
+            event_type="bank_account.renamed",
+            source="users-service",
+            timestamp=datetime.now(),
+            payload={
+                "user_id": user_id,
+                "bank_account_hash": account.bank_account_hash,
+                "new_name": new_name,
+            },
+        )
+        await publisher.publish(event)
+
+        return account
+
     async def get_all_by_user_id(self, user_id: int):
         """Получить все банковские счета пользователя с информацией о банке"""
         from sqlalchemy.orm import selectinload

--- a/users_service/app/routers/bank_account.py
+++ b/users_service/app/routers/bank_account.py
@@ -9,7 +9,7 @@ from app.cache import (
 from app.repository.bank_account_repository import Bank_AccountRepository
 from app.repository.user_repository import UserRepository
 from app.routers.users import get_bank_account_repository, get_user_repository
-from app.schemas import Bank_AccountCreate, Bank_accountResponse, oauth2_scheme
+from app.schemas import Bank_AccountCreate, Bank_accountResponse, BankAccountRenameRequest, oauth2_scheme
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 router = APIRouter(prefix="/me", tags=["bank_account"])
@@ -99,6 +99,31 @@ async def get_user_bank_accounts(
     await cache_client.set(cache_key, result, ttl=BANK_ACCOUNTS_TTL)
 
     return result
+
+
+@router.patch("/bank_account/{bank_account_id}", response_model=Bank_accountResponse)
+async def rename_bank_account(
+    bank_account_id: int,
+    rename_data: BankAccountRenameRequest,
+    user=Depends(get_current_user),
+    bank_account_repo: Bank_AccountRepository = Depends(get_bank_account_repository),
+):
+    """Переименовать банковский счёт"""
+    user_id = user.id
+
+    account = await bank_account_repo.rename(bank_account_id, user_id, rename_data.bank_account_name)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bank account not found")
+
+    await cache_client.delete(bank_accounts_key(user_id))
+
+    return {
+        "bank_account_id": account.bank_account_id,
+        "bank_account_name": account.bank_account_name,
+        "currency": account.currency,
+        "bank": account.bank.name,
+        "balance": account.balance,
+    }
 
 
 @router.delete("/bank_account/{bank_account_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/users_service/app/schemas.py
+++ b/users_service/app/schemas.py
@@ -168,6 +168,20 @@ class Bank_AccountCreate(BaseModel):
     bank: str
 
 
+class BankAccountRenameRequest(BaseModel):
+    """Схема переименования банковского счета"""
+
+    bank_account_name: str = Field(..., min_length=1, max_length=100)
+
+    @field_validator("bank_account_name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Name cannot be empty")
+        return v
+
+
 class Bank_accountResponse(BaseModel):
     """Схема банковского счета"""
 

--- a/users_service/tests/integration/test_bank_account_integration.py
+++ b/users_service/tests/integration/test_bank_account_integration.py
@@ -126,9 +126,8 @@ async def test_rename_not_my_account(
     db_session,
 ):
     """❌ Попытка переименовать чужой счёт"""
-    from passlib.context import CryptContext
-
     from app.models import Bank, Bank_Accounts, User
+    from passlib.context import CryptContext
 
     pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
     other_user = User(

--- a/users_service/tests/integration/test_bank_account_integration.py
+++ b/users_service/tests/integration/test_bank_account_integration.py
@@ -68,6 +68,103 @@ async def test_delete_bank_account(client: AsyncClient, auth_headers: dict, mock
     assert del_resp.status_code == 204
 
 
+async def test_rename_bank_account_success(
+    client: AsyncClient, auth_headers: dict, mock_bank_service, mock_event_publisher
+):
+    """✅ Успешное переименование счёта"""
+    create_resp = await client.post(
+        "/me/bank_account",
+        json={"bank_account_number": "40817810099910004315", "bank_account_name": "Старое имя", "bank": "Сбер"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    account_id = create_resp.json()["bank_account_id"]
+
+    rename_resp = await client.patch(
+        f"/me/bank_account/{account_id}",
+        json={"bank_account_name": "Новое имя"},
+        headers=auth_headers,
+    )
+    assert rename_resp.status_code == 200
+    data = rename_resp.json()
+    assert data["bank_account_name"] == "Новое имя"
+    assert data["bank_account_id"] == account_id
+
+
+async def test_rename_bank_account_not_found(client: AsyncClient, auth_headers: dict):
+    """❌ Переименование несуществующего счёта"""
+    rename_resp = await client.patch(
+        "/me/bank_account/99999",
+        json={"bank_account_name": "Новое имя"},
+        headers=auth_headers,
+    )
+    assert rename_resp.status_code == 404
+
+
+async def test_rename_bank_account_unauthorized(client: AsyncClient):
+    """❌ Попытка переименования без токена"""
+    rename_resp = await client.patch(
+        "/me/bank_account/1",
+        json={"bank_account_name": "Новое имя"},
+    )
+    assert rename_resp.status_code == 401
+
+
+async def test_rename_bank_account_empty_name(client: AsyncClient, auth_headers: dict):
+    """❌ Пустое название — 422"""
+    rename_resp = await client.patch(
+        "/me/bank_account/1",
+        json={"bank_account_name": "   "},
+        headers=auth_headers,
+    )
+    assert rename_resp.status_code == 422
+
+
+async def test_rename_not_my_account(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+):
+    """❌ Попытка переименовать чужой счёт"""
+    from passlib.context import CryptContext
+
+    from app.models import Bank, Bank_Accounts, User
+
+    pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+    other_user = User(
+        email="rename_other@test.com",
+        hashed_password=pwd_context.hash("pass"),
+        first_name="Other",
+        last_name="User",
+        is_active=True,
+    )
+    db_session.add(other_user)
+    bank = Bank(name="RenameBankOther")
+    db_session.add(bank)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    await db_session.refresh(bank)
+
+    other_account = Bank_Accounts(
+        user_id=other_user.id,
+        bank_id=bank.id,
+        bank_account_hash="rename_hash_other",
+        bank_account_name="Чужой счёт",
+        currency="RUB",
+        balance=0,
+    )
+    db_session.add(other_account)
+    await db_session.commit()
+    await db_session.refresh(other_account)
+
+    rename_resp = await client.patch(
+        f"/me/bank_account/{other_account.bank_account_id}",
+        json={"bank_account_name": "Попытка взлома"},
+        headers=auth_headers,
+    )
+    assert rename_resp.status_code == 404
+
+
 async def test_delete_not_my_account(
     client: AsyncClient,
     test_user: User,

--- a/users_service/tests/unit/repository/test_bank_account_repository.py
+++ b/users_service/tests/unit/repository/test_bank_account_repository.py
@@ -249,6 +249,76 @@ async def test_create_bank_auto_created(
     assert any(isinstance(obj, Bank) for obj in added_objects), "Bank object should be added to session"
 
 
+async def test_rename_success(mock_db_session):
+    """Успешное переименование банковского счёта"""
+    from unittest.mock import MagicMock
+
+    from app.models import Bank_Accounts
+    from app.repository.bank_account_repository import Bank_AccountRepository
+
+    existing_account = MagicMock(spec=Bank_Accounts)
+    existing_account.bank_account_name = "Старое имя"
+
+    mock_scalar_result = MagicMock()
+    mock_scalar_result.first.return_value = existing_account
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalar_result
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+    repo = Bank_AccountRepository(db=mock_db_session)
+    result = await repo.rename(bank_account_id=1, user_id=1, new_name="Новое имя")
+
+    assert result is existing_account
+    assert existing_account.bank_account_name == "Новое имя"
+    mock_db_session.commit.assert_called_once()
+    mock_db_session.refresh.assert_called_once_with(existing_account)
+
+
+@patch("app.repository.bank_account_repository.EventPublisher")
+async def test_rename_publishes_event(mock_event_publisher_class, mock_db_session):
+    """После переименования публикуется событие bank_account.renamed"""
+    from app.models import Bank_Accounts
+    from app.repository.bank_account_repository import Bank_AccountRepository
+
+    existing_account = MagicMock(spec=Bank_Accounts)
+    existing_account.bank_account_hash = "abc123"
+
+    mock_scalar_result = MagicMock()
+    mock_scalar_result.first.return_value = existing_account
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalar_result
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+    mock_publisher_instance = AsyncMock()
+    mock_event_publisher_class.return_value = mock_publisher_instance
+
+    repo = Bank_AccountRepository(db=mock_db_session)
+    await repo.rename(bank_account_id=1, user_id=1, new_name="Новое имя")
+
+    mock_publisher_instance.publish.assert_awaited_once()
+    published_event = mock_publisher_instance.publish.call_args[0][0]
+    assert published_event.event_type == "bank_account.renamed"
+    assert published_event.payload["new_name"] == "Новое имя"
+    assert published_event.payload["bank_account_hash"] == "abc123"
+
+
+async def test_rename_account_not_found(mock_db_session):
+    """Счёт не найден — возвращает None"""
+    from app.repository.bank_account_repository import Bank_AccountRepository
+
+    mock_scalar_result = MagicMock()
+    mock_scalar_result.first.return_value = None
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalar_result
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+    repo = Bank_AccountRepository(db=mock_db_session)
+    result = await repo.rename(bank_account_id=999, user_id=1, new_name="Новое имя")
+
+    assert result is None
+    mock_db_session.commit.assert_not_called()
+
+
 async def test_create_strips_account_number(mock_db_session, mock_hash_function, mock_httpx_async_client):
     """Проверяем, что номер счёта очищается от пробелов"""
     from app.repository.bank_account_repository import Bank_AccountRepository


### PR DESCRIPTION
# Что сделано?

1. Добавлена новая ручка /users/me/bank_account/{bank_account_id}, для того чтобы менять имя счета.
2. Добавлена фильтрация по счету в ручку /transactions/, можно фильтровать по нескольким счетам.
3. Исправлены баги с уведомлениями, теперь если мы пересекли сразу несколько порогов по пополнению цели, то нам придет уведомление только по большему порогу.
4. Теперь при синхронизации счетов у нас приходит только одно уведомление синхронизации в котором суммируются транзакции со всех счетов. Тем самым мы не захламляем панель с уведомлениями для истории.